### PR TITLE
Implement the OAuth2 client and provide config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,57 @@ Or install it yourself as:
 
 ## Usage
 
-TODO.
+Starling uses [OAuth2][] for authentication. There's two endpoints (production
+and a sandbox) using the full flow and [personal access tokens][] which allow
+you to create tokens for your own account, bypassing the redirects.
+
+### Standard OAuth2
+
+After creating an application (in either sandbox or production), set the
+`client_id`, `client_secret`, and `redirect_uri`. Optionally, set
+`environment` (which defaults to `:production`.)
+
+```ruby
+Sturnus.configure do |config|
+  config.environment = :sandbox #=> :production
+  config.client_id = ""
+  config.client_secret = ""
+  config.redirect_uri = ""
+end
+```
+
+`Starnus::Client` wraps the [`oauth2` gem][gem] and provides a few methods to
+help:
+
+```ruby
+client = Starnus.client
+client.authorize_url # to redirect to
+client.exchange_token(code) # from the post you got back
+```
+
+You can pull the configured client object out from `Starnus.client`, then
+generate the URL to redirect which the user will be redirected to (using
+`authorize_url`), followed by getting an access token using the code which came
+back (`exchange_token`). The token will be used from this point onwards.
+
+### Personal Access Tokens
+
+After creating a [personal access token][], pass this into the `configure`
+block directly:
+
+```ruby
+Sturnus.configure do |config|
+  config.access_token = "YOUR_TOKEN"
+end
+```
+
+You won't need to set `environment`, `client_id`, `client_secret` or
+`redirect_uri`.
+
+[OAuth2]: https://tools.ietf.org/html/rfc6749
+[gem]: https://github.com/intridea/oauth2
+[personal access token]: https://developer.starlingbank.com/token/new
+[personal access tokens]: https://developer.starlingbank.com/token/new
 
 ## Development
 

--- a/lib/sturnus.rb
+++ b/lib/sturnus.rb
@@ -1,4 +1,14 @@
+require "oauth2"
+
 require "sturnus/version"
+require "sturnus/errors"
+require "sturnus/configuration"
+require "sturnus/client"
 
 module Sturnus
+  attr_accessor :client
+
+  def self.client
+    @client ||= Client.new(configuration)
+  end
 end

--- a/lib/sturnus/client.rb
+++ b/lib/sturnus/client.rb
@@ -1,0 +1,51 @@
+module Sturnus
+  class Client
+    include Sturnus::Errors
+
+    def initialize(config)
+      @configuration = config
+      @oauth_client = OAuth2::Client.new(
+        config.client_id,
+        config.client_secret,
+        site: config.endpoint,
+        authorize_url: "https://oauth.starlingbank.com/oauth/authorize",
+        token_url: "https://api.starlingbank.com/oauth/access-token",
+      )
+    end
+
+    def authorize_url
+      oauth_client.auth_code.authorize_url(redirect_uri:
+        configuration.redirect_uri)
+    end
+
+    def exchange_token(code)
+      @token = oauth_client.auth_code.get_token(
+        code,
+        redirect_url: configuration.redirect_uri,
+      )
+    end
+
+    def token
+      @token ||= OAuth2::AccessToken.new(oauth_client,
+                                         configuration.access_token)
+    end
+
+    %w(get put post delete).each do |m|
+      define_method(m) do |path, opts = {}|
+        validate!
+
+        token.request(m.to_sym, path, opts)
+      end
+    end
+
+    private
+
+    attr_reader :configuration, :oauth_client
+
+    def validate!
+      if token.token.empty?
+        raise AuthenticationError, "missing access token"
+      end
+    end
+  end
+end

--- a/lib/sturnus/configuration.rb
+++ b/lib/sturnus/configuration.rb
@@ -1,0 +1,52 @@
+module Sturnus
+  class Configuration
+    attr_accessor :client_id, :client_secret, :redirect_uri,
+                  :access_token, :environment
+
+    def initialize(opts = {})
+      opts.each do |k, v|
+        send("#{k}=".to_sym, v)
+      end
+    end
+
+    def environment
+      @environment ||= :production
+    end
+
+    def endpoint
+      case environment
+      when :sandbox
+        "https://api-sandbox.starlingbank.com"
+      when :production
+        "https://api.starlingbank.com"
+      end
+    end
+
+    def to_h
+      {
+        client_id: client_id,
+        client_secret: client_secret,
+        redirect_uri: redirect_uri,
+        access_token: access_token,
+        environment: environment,
+      }
+    end
+
+    def to_s
+      objects = to_h.map { |k, v| "#{k}=#{v}" }.join(" ")
+      "#<#{self.class.name}:#{object_id} #{objects}"
+    end
+  end
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    yield configuration if block_given?
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+end

--- a/lib/sturnus/errors.rb
+++ b/lib/sturnus/errors.rb
@@ -1,0 +1,9 @@
+module Sturnus
+  module Errors
+    # Generic Error
+    class SturnusError < StandardError; end
+
+    # Authentication Error
+    class AuthenticationError < SturnusError; end
+  end
+end

--- a/spec/fixtures/oauth_access_token.json
+++ b/spec/fixtures/oauth_access_token.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "bW3kAkyNWCYUvNG6QFBLoiZc1YbGGblvLFW9FYvNzMF0FAidxNoPZP5gsN1T3NiS",
+  "refresh_token": "Km9frBk55jnZdY9RZktUfyFPTDi8JUWwdPdDwG68yjWYe2c8RVuTtrtjJ46eTl5M",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "balance:read payee:read transaction:read"
+}

--- a/spec/fixtures/v1_me.json
+++ b/spec/fixtures/v1_me.json
@@ -1,0 +1,1 @@
+{"customerUid":"18c0cf35-6d7d-4b80-9ee7-10baaea6021a","authenticated":true,"expiresInSeconds":0,"scopes":["account:read","balance:read","address:read","address:edit","card:read","customer:read","mandate:read","mandate:delete","payee:create","payee:read","transaction:read","transaction:edit"]}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 require "bundler/setup"
+require "webmock/rspec"
 require "sturnus"
+
+def fixture(file_name)
+  file = File.expand_path("../../spec/fixtures/#{file_name}", __FILE__)
+
+  File.read(file)
+end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/sturnus/client_spec.rb
+++ b/spec/sturnus/client_spec.rb
@@ -1,0 +1,105 @@
+require "spec_helper"
+
+RSpec.describe Sturnus::Client do
+  describe "#authorize_url" do
+    it "creates a URL for the user to be redirected to" do
+      client = described_class.new(oauth_config)
+
+      expect(client.authorize_url).to eq("https://oauth.starlingbank.com" \
+        "/oauth/authorize?client_id=abc&" \
+        "redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&response_type=code")
+    end
+  end
+
+  describe "#exchange_token" do
+    it "gets an access token for an authorisation code" do
+      stub_request(:post, "https://api.starlingbank.com/oauth/access-token").
+        with(body: { "client_id" => "abc", "client_secret" => "xyz",
+                     "code" => "1234567890abcdefghikjlmnopqrstuvwxyz",
+                     "grant_type" => "authorization_code",
+                     "redirect_url" => "https://example.com/redirect" }).
+        to_return(body: fixture("oauth_access_token.json"),
+                  status: 200,
+                  headers: { "Content-Type" => "application/json" })
+
+      client = described_class.new(oauth_config)
+      token = client.exchange_token("1234567890abcdefghikjlmnopqrstuvwxyz")
+
+      expect(token).to have_attributes(
+        token: "bW3kAkyNWCYUvNG6QFBLoiZc1YbGGblvLFW9FYvNzMF0FAidxNo" \
+                "PZP5gsN1T3NiS",
+        refresh_token: "Km9frBk55jnZdY9RZktUfyFPTDi8JUWwdPdDwG68yjW" \
+                "Ye2c8RVuTtrtjJ46eTl5M",
+        expires_in: 3600,
+      )
+    end
+  end
+
+  describe "#token" do
+    context "when an access token comes from an OAuth flow" do
+      it "has the access token from exchange_token" do
+        stub_request(:post, "https://api.starlingbank.com/oauth/access-token").
+          with(body: { "client_id" => "abc", "client_secret" => "xyz",
+                       "code" => "1234567890abcdefghikjlmnopqrstuvwxyz",
+                       "grant_type" => "authorization_code",
+                       "redirect_url" => "https://example.com/redirect" }).
+          to_return(body: fixture("oauth_access_token.json"),
+                    status: 200,
+                    headers: { "Content-Type" => "application/json" })
+
+        client = described_class.new(oauth_config)
+        client.exchange_token("1234567890abcdefghikjlmnopqrstuvwxyz")
+        token = client.token
+
+        expect(token).to have_attributes(
+          token: "bW3kAkyNWCYUvNG6QFBLoiZc1YbGGblvLFW9FYvNzMF0FAidxNo" \
+            "PZP5gsN1T3NiS",
+          expires_in: 3600,
+        )
+      end
+    end
+
+    context "when an access token is provided directly" do
+      it "has the access token from the configuration" do
+        client = described_class.new(personal_token_config)
+        token = client.token
+
+        expect(token).to have_attributes(token: "abc", expires_in: nil)
+      end
+    end
+  end
+
+  describe "#get" do
+    it "raises an error if the token isn't set" do
+      client = described_class.new(oauth_config)
+
+      expect do
+        client.get("/api/v1/me")
+      end.to raise_error(Sturnus::Errors::AuthenticationError,
+                         "missing access token")
+    end
+
+    it "makes a request using the token" do
+      config = personal_token_config
+      stub_request(:get, "#{config.endpoint}/api/v1/me").
+        to_return(body: fixture("v1_me.json"), status: 200)
+
+      client = described_class.new(config)
+      response = client.get("/api/v1/me")
+
+      expect(response).to have_attributes(status: 200, error: nil)
+    end
+  end
+
+  def oauth_config
+    Sturnus::Configuration.new(
+      client_id: "abc",
+      client_secret: "xyz",
+      redirect_uri: "https://example.com/redirect",
+    )
+  end
+
+  def personal_token_config
+    Sturnus::Configuration.new(access_token: "abc")
+  end
+end

--- a/spec/sturnus/configuration_spec.rb
+++ b/spec/sturnus/configuration_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+RSpec.describe Sturnus::Configuration do
+  it "has configured accessors" do
+    expect(config).to have_attributes(
+      client_id: "abc",
+      client_secret: "xyz",
+      redirect_uri: "https://example.com/redirect",
+      access_token: "123",
+    )
+  end
+
+  describe "#environment" do
+    it "is :production when not set" do
+      config = described_class.new
+
+      expect(config.environment).to eq(:production)
+    end
+
+    it "can be set" do
+      config = described_class.new(environment: :something_else)
+
+      expect(config.environment).to eq(:something_else)
+    end
+  end
+
+  describe "#endpoint" do
+    it "has the correct value when in sandbox" do
+      config = described_class.new(environment: :sandbox)
+
+      expect(config.endpoint).
+        to eq("https://api-sandbox.starlingbank.com")
+    end
+
+    it "has the correct value when in production" do
+      config = described_class.new(environment: :production)
+
+      expect(config.endpoint).to eq("https://api.starlingbank.com")
+    end
+  end
+
+  describe "#to_h" do
+    it "has a hash representation" do
+      expect(config.to_h).to eq(
+        client_id: "abc",
+        client_secret: "xyz",
+        redirect_uri: "https://example.com/redirect",
+        access_token: "123",
+        environment: :production,
+      )
+    end
+  end
+
+  def config
+    Sturnus::Configuration.new(
+      client_id: "abc",
+      client_secret: "xyz",
+      redirect_uri: "https://example.com/redirect",
+      access_token: "123",
+    )
+  end
+end

--- a/spec/sturnus_spec.rb
+++ b/spec/sturnus_spec.rb
@@ -4,4 +4,29 @@ RSpec.describe Sturnus do
   it "has a version number" do
     expect(Sturnus::VERSION).not_to be nil
   end
+
+  describe "#configure" do
+    it "yields a configuration object" do
+      config = Sturnus::Configuration.new
+      allow(Sturnus).to receive(:configuration).and_return(config)
+
+      expect do |b|
+        Sturnus.configure(&b)
+      end.to yield_with_args(config)
+
+      expect(Sturnus).to have_received(:configuration)
+    end
+  end
+
+  describe "#configuration" do
+    it "has a configuration" do
+      expect(Sturnus.configuration).to be_a(Sturnus::Configuration)
+    end
+  end
+
+  describe "#client" do
+    it "has a client" do
+      expect(Sturnus.client).to be_a(Sturnus::Client)
+    end
+  end
 end

--- a/sturnus.gemspec
+++ b/sturnus.gemspec
@@ -22,8 +22,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "oauth2"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
* Provides a `Client` class to wrap the `oauth2` gem and integrate it.
* Provide a `Configuration` class, which can be yielded to provide the
  configuration on first-use.
* Documents how to use with standard OAuth2 and personal access tokens.