### PR TITLE
Link a Customer to itself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ names is lost (`customerUid` becomes `uid`) and `snake_case` is preferred over
 
 [representable]: http://trailblazer.to/gems/representable
 
+### Following Links
+
+Each of the resource objects support the `_links` attribute in the response and
+can follow them (including unpacking into the correct `Sturnus::Resource`
+subclass. For example:
+
+```ruby
+customer = Sturnus::Customer.get
+customer._links["self"].get #=> #<Sturnus::Customer:0x007f8326a93cf0 @_links=..
+```
+
+When the original resource is parsed, each of the links becomes a `Hyperlink`
+object which can determine the correct resource (through the URL) through a
+lookup table (`Sturnus.models`).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/lib/sturnus.rb
+++ b/lib/sturnus.rb
@@ -6,6 +6,9 @@ require "sturnus/version"
 require "sturnus/errors"
 require "sturnus/configuration"
 require "sturnus/client"
+require "sturnus/hyperlink"
+require "sturnus/resource"
+require "sturnus/representers/base"
 
 require "sturnus/representers/customer"
 require "sturnus/customer"
@@ -15,5 +18,11 @@ module Sturnus
 
   def self.client
     @client ||= Client.new(configuration)
+  end
+
+  def self.models
+    {
+      "customers" => Customer,
+    }
   end
 end

--- a/lib/sturnus/customer.rb
+++ b/lib/sturnus/customer.rb
@@ -1,5 +1,5 @@
 module Sturnus
-  class Customer
+  class Customer < Resource
     URL = "/api/v1/customers".freeze
 
     attr_accessor :uid, :first_name, :last_name, :date_of_birth, :email, :phone

--- a/lib/sturnus/hyperlink.rb
+++ b/lib/sturnus/hyperlink.rb
@@ -1,0 +1,26 @@
+module Sturnus
+  class Hyperlink
+    attr_reader :link, :templated
+
+    def initialize(link, templated)
+      @link = link
+      @templated = templated
+    end
+
+    def get
+      model_klass_with(link: link)&.get
+    end
+
+    private
+
+    def model_klass_with(link:)
+      matching_key = models.keys.detect { |key| link.match(key) }
+
+      models[matching_key]
+    end
+
+    def models
+      Sturnus.models
+    end
+  end
+end

--- a/lib/sturnus/representers/base.rb
+++ b/lib/sturnus/representers/base.rb
@@ -1,0 +1,10 @@
+module Sturnus
+  module Representers
+    class Base < Representable::Decorator
+      include Representable::JSON
+      include Representable::Coercion
+
+      property :_links
+    end
+  end
+end

--- a/lib/sturnus/representers/customer.rb
+++ b/lib/sturnus/representers/customer.rb
@@ -1,9 +1,6 @@
 module Sturnus
   module Representers
-    class Customer < Representable::Decorator
-      include Representable::JSON
-      include Representable::Coercion
-
+    class Customer < Base
       property :uid, as: :customerUid
       property :first_name, as: :firstName
       property :last_name, as: :lastName

--- a/lib/sturnus/resource.rb
+++ b/lib/sturnus/resource.rb
@@ -1,0 +1,11 @@
+module Sturnus
+  class Resource
+    attr_reader :_links
+
+    def _links=(attr)
+      @_links = attr.map do |name, link|
+        [name, Hyperlink.new(link["href"], link["templated"])]
+      end.to_h
+    end
+  end
+end

--- a/spec/sturnus/customer_spec.rb
+++ b/spec/sturnus/customer_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe Sturnus::Customer do
         phone: "40e5cf47-9774-405a-9193-35f002",
       )
     end
+
+    it "links to self" do
+      stub_request(:get, url("/api/v1/customers")).
+        to_return(body: fixture("v1_customers.json"), status: 200)
+
+      customer = described_class.get
+
+      expect(customer._links["self"].get).to have_attributes(
+        uid: "40e5cf47-9774-405a-9193-35f002d9c8ef",
+        first_name: "Dirk",
+        last_name: "Gently",
+      )
+    end
   end
 
   def url(segment)

--- a/spec/sturnus/hyperlink_spec.rb
+++ b/spec/sturnus/hyperlink_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Sturnus::Hyperlink do
+  describe ".get" do
+    context "when setup with a valid resource url" do
+      it "calls #get on the relevant model" do
+        class Example
+          def self.get; end
+        end
+
+        allow(Sturnus).to receive(:models).and_return(
+          "examples" => Example,
+        )
+        allow(Example).to receive(:get)
+
+        link = described_class.new("api/v1/examples", false)
+        link.get
+
+        expect(Example).to have_received(:get)
+      end
+    end
+
+    context "when setup with an unknown url" do
+      it "returns nil" do
+        link = described_class.new("api/v1/examples", false)
+
+        expect(link.get).to be_nil
+      end
+    end
+  end
+end

--- a/spec/sturnus/resource_spec.rb
+++ b/spec/sturnus/resource_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe Sturnus::Resource do
+  describe "links" do
+    it "builds a hash of links from a response" do
+      response = {
+        "self" => {
+          "href" => "api/v1/customers",
+          "templated" => false,
+        },
+      }
+
+      resource = described_class.new
+      resource._links = response
+
+      links_self = resource._links["self"]
+      expect(links_self).to have_attributes(
+        link: "api/v1/customers",
+        templated: false,
+      )
+    end
+  end
+end


### PR DESCRIPTION
* Following the self link in a Customer will unpack another Customer
  object.
* Hyperlink objects are built from the _links in the response.
* Calling #get on a Hyperlink passes through to the .get on the original
  model class.
* Links are unpacked using a registry of names to their classes in
  Sturnus.models depending on what the URL looks like.
* Extracts a base resource and base representer to move common elements
  out.