### PR TITLE
Extract a build_url helper method.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,12 @@ def fixture(file_name)
   File.read(file)
 end
 
+def build_url(segment)
+  config = Sturnus.configuration
+
+  "#{config.endpoint}#{segment}"
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/sturnus/account_spec.rb
+++ b/spec/sturnus/account_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sturnus::Account do
 
   describe ".get" do
     it "fetches the current account" do
-      stub_request(:get, url("/api/v1/accounts")).
+      stub_request(:get, build_url("/api/v1/accounts")).
         to_return(body: fixture("v1_accounts.json"), status: 200)
 
       account = described_class.get
@@ -29,7 +29,7 @@ RSpec.describe Sturnus::Account do
 
     it "links to self" do
       pending "the Starling API doesn't specify a self link on /v1/accounts"
-      stub_request(:get, url("/api/v1/accounts")).
+      stub_request(:get, build_url("/api/v1/accounts")).
         to_return(body: fixture("v1_accounts.json"), status: 200)
 
       account = described_class.get
@@ -41,11 +41,5 @@ RSpec.describe Sturnus::Account do
         sort_code: "123456",
       )
     end
-  end
-
-  def url(segment)
-    config = Sturnus.configuration
-
-    "#{config.endpoint}#{segment}"
   end
 end

--- a/spec/sturnus/customer_spec.rb
+++ b/spec/sturnus/customer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Sturnus::Customer do
 
   describe ".get" do
     it "fetches the current customer" do
-      stub_request(:get, url("/api/v1/customers")).
+      stub_request(:get, build_url("/api/v1/customers")).
         to_return(body: fixture("v1_customers.json"), status: 200)
 
       customer = described_class.get
@@ -26,7 +26,7 @@ RSpec.describe Sturnus::Customer do
     end
 
     it "links to self" do
-      stub_request(:get, url("/api/v1/customers")).
+      stub_request(:get, build_url("/api/v1/customers")).
         to_return(body: fixture("v1_customers.json"), status: 200)
 
       customer = described_class.get
@@ -39,9 +39,9 @@ RSpec.describe Sturnus::Customer do
     end
 
     it "links to accounts" do
-      stub_request(:get, url("/api/v1/customers")).
+      stub_request(:get, build_url("/api/v1/customers")).
         to_return(body: fixture("v1_customers.json"), status: 200)
-      stub_request(:get, url("/api/v1/accounts")).
+      stub_request(:get, build_url("/api/v1/accounts")).
         to_return(body: fixture("v1_accounts.json"), status: 200)
 
       customer = described_class.get
@@ -54,11 +54,5 @@ RSpec.describe Sturnus::Customer do
         sort_code: "123456",
       )
     end
-  end
-
-  def url(segment)
-    config = Sturnus.configuration
-
-    "#{config.endpoint}#{segment}"
   end
 end


### PR DESCRIPTION
This saves us repeating inside each spec.